### PR TITLE
Add configurable base dashboard URI

### DIFF
--- a/config/paket.php
+++ b/config/paket.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Laravel Paket.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Paket URI
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Paket will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API that aren't exposed to users.
+    |
+    */
+
+    'uri' => env('PAKET_URI', 'paket'),
+
+];

--- a/config/paket.php
+++ b/config/paket.php
@@ -19,8 +19,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This is the URI path where Paket will be accessible from. Feel free
-    | to change this path to anything you like. Note that the URI will not
-    | affect the paths of its internal API that aren't exposed to users.
+    | to change this path to anything you like.
     |
     */
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:nGpI2Trh/XgW0GXg3YMsuYGStSgG7z/XTkNYXKu0rrU="/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/src/PaketServiceProvider.php
+++ b/src/PaketServiceProvider.php
@@ -28,6 +28,7 @@ final class PaketServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->configure();
         $this->registerConsoleCommands();
     }
 
@@ -44,9 +45,21 @@ final class PaketServiceProvider extends ServiceProvider
     {
         return [
             'namespace' => 'Cog\Laravel\Paket\Http\Controllers',
-            'prefix' => 'paket',
+            'prefix' => config('paket.uri'),
             'middleware' => 'web',
         ];
+    }
+
+    /**
+     * Merge Paket configuration with the application configuration.
+     *
+     * @return void
+     */
+    private function configure(): void
+    {
+        if (!$this->app->configurationIsCached()) {
+            $this->mergeConfigFrom(__DIR__ . '/../config/paket.php', 'paket');
+        }
     }
 
     private function registerResources(): void
@@ -60,6 +73,10 @@ final class PaketServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/../public' => public_path('vendor/paket'),
             ], 'paket-assets');
+
+            $this->publishes([
+                __DIR__ . '/../config/paket.php' => config_path('paket.php'),
+            ], 'paket-config');
         }
     }
 

--- a/tests/Feature/App/ActionTest.php
+++ b/tests/Feature/App/ActionTest.php
@@ -22,6 +22,8 @@ final class ActionTest extends TestCase
     {
         $response = $this->get('/paket');
 
+        dd($response);
+
         $response->assertStatus(200);
     }
 }

--- a/tests/Feature/App/ActionTest.php
+++ b/tests/Feature/App/ActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Laravel Paket.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Tests\Laravel\Paket\Feature\App;
+
+use Cog\Tests\Laravel\Paket\TestCase;
+
+final class ActionTest extends TestCase
+{
+    /** @test */
+    public function it_visible_to_guest(): void
+    {
+        $response = $this->get('/paket');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/App/ActionTest.php
+++ b/tests/Feature/App/ActionTest.php
@@ -20,9 +20,9 @@ final class ActionTest extends TestCase
     /** @test */
     public function it_visible_to_guest(): void
     {
-        $response = $this->get('/paket');
+        $this->artisan('paket:setup');
 
-        dd($response);
+        $response = $this->get('/paket');
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/App/ActionTest.php
+++ b/tests/Feature/App/ActionTest.php
@@ -20,8 +20,6 @@ final class ActionTest extends TestCase
     /** @test */
     public function it_visible_to_guest(): void
     {
-        $this->artisan('paket:setup');
-
         $response = $this->get('/paket');
 
         $response->assertStatus(200);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,8 @@ abstract class TestCase extends OrchestraTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->artisan('paket:setup');
     }
 
     /**


### PR DESCRIPTION
Base URI will be configurable in `config/paket.php` file.

You may export configuration file using the `php artisan vendor:publish --tag=paket-config` command.