### PR TITLE
Make global route middleware configurable

### DIFF
--- a/config/paket.php
+++ b/config/paket.php
@@ -25,4 +25,19 @@ return [
 
     'base_uri' => env('PAKET_BASE_URI', 'paket'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Paket Route Middlewares
+    |--------------------------------------------------------------------------
+    |
+    | These middlewares will be assigned to every Paket route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middlewares. Or, you can simply stick with this list.
+    |
+    */
+
+    'middlewares' => [
+        'web',
+    ],
+
 ];

--- a/src/PaketServiceProvider.php
+++ b/src/PaketServiceProvider.php
@@ -20,6 +20,7 @@ use Cog\Laravel\Paket\Job\Listeners\JobListener;
 use Cog\Laravel\Paket\Job\Repositories\JobFileRepository;
 use Cog\Laravel\Paket\Support\Composer;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -34,6 +35,7 @@ final class PaketServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->registerMiddlewareGroups();
         $this->registerPublishes();
         $this->registerResources();
         $this->registerRoutes();
@@ -45,8 +47,8 @@ final class PaketServiceProvider extends ServiceProvider
     {
         return [
             'namespace' => 'Cog\Laravel\Paket\Http\Controllers',
-            'prefix' => config('paket.base_uri'),
-            'middleware' => 'web',
+            'prefix' => Config::get('paket.base_uri'),
+            'middleware' => 'paket',
         ];
     }
 
@@ -60,6 +62,11 @@ final class PaketServiceProvider extends ServiceProvider
         if (!$this->app->configurationIsCached()) {
             $this->mergeConfigFrom(__DIR__ . '/../config/paket.php', 'paket');
         }
+    }
+
+    private function registerMiddlewareGroups(): void
+    {
+        Route::middlewareGroup('paket', Config::get('paket.middlewares', []));
     }
 
     private function registerResources(): void


### PR DESCRIPTION
Part of the #12 issue.

Paket global route middlewares could be configured  in `config/paket.php` file `paket.middlewares` key.

You may export configuration file using the `php artisan vendor:publish --tag=paket-config` command.