### PR TITLE
Add Authorize middleware

### DIFF
--- a/config/paket.php
+++ b/config/paket.php
@@ -11,6 +11,8 @@
 
 declare(strict_types=1);
 
+use Cog\Laravel\Paket\Http\Middlewares\Authorize;
+
 return [
 
     /*
@@ -38,6 +40,7 @@ return [
 
     'middlewares' => [
         'web',
+        Authorize::class,
     ],
 
 ];

--- a/src/Http/Middlewares/Authorize.php
+++ b/src/Http/Middlewares/Authorize.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Laravel Paket.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\Laravel\Paket\Http\Middlewares;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class Authorize
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        return app()->environment('local') ? $next($request) : abort(403);
+    }
+}

--- a/tests/Feature/App/ActionTest.php
+++ b/tests/Feature/App/ActionTest.php
@@ -13,12 +13,24 @@ declare(strict_types=1);
 
 namespace Cog\Tests\Laravel\Paket\Feature\App;
 
+use Cog\Laravel\Paket\Http\Middlewares\Authorize;
 use Cog\Tests\Laravel\Paket\TestCase;
+use Orchestra\Testbench\Http\Middleware\VerifyCsrfToken;
 
 final class ActionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            Authorize::class,
+            VerifyCsrfToken::class,
+        ]);
+    }
+
     /** @test */
-    public function it_visible_to_guest(): void
+    public function it_exposes_dashboard_when_url_is_default(): void
     {
         $response = $this->get('/paket');
 


### PR DESCRIPTION
Implements #12 

Allows to use Paket in `local` environment only.

This behavior could be configured  in `config/paket.php` file `paket.middlewares` key. `Authorize` middleware class is responsible for this restriction.

You may export configuration file using the `php artisan vendor:publish --tag=paket-config` command.