### PR TITLE
Change name of job listener

### DIFF
--- a/src/Job/Listeners/JobRunner.php
+++ b/src/Job/Listeners/JobRunner.php
@@ -17,7 +17,7 @@ use Cog\Laravel\Paket\Job\Events\JobHasBeenCreated;
 use Cog\Laravel\Paket\Job\QueueJobs\RunJob;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-final class JobListener implements ShouldQueue
+final class JobRunner implements ShouldQueue
 {
     public function handle(JobHasBeenCreated $event): void
     {

--- a/src/PaketServiceProvider.php
+++ b/src/PaketServiceProvider.php
@@ -16,7 +16,7 @@ namespace Cog\Laravel\Paket;
 use Cog\Contracts\Paket\Job\Repositories\Job as JobRepositoryContract;
 use Cog\Laravel\Paket\Console\Commands\Setup;
 use Cog\Laravel\Paket\Job\Events\JobHasBeenCreated;
-use Cog\Laravel\Paket\Job\Listeners\JobListener;
+use Cog\Laravel\Paket\Job\Listeners\JobRunner;
 use Cog\Laravel\Paket\Job\Repositories\JobFileRepository;
 use Cog\Laravel\Paket\Support\Composer;
 use Illuminate\Filesystem\Filesystem;
@@ -121,6 +121,6 @@ final class PaketServiceProvider extends ServiceProvider
 
     private function registerListeners(): void
     {
-        Event::listen(JobHasBeenCreated::class, JobListener::class);
+        Event::listen(JobHasBeenCreated::class, JobRunner::class);
     }
 }


### PR DESCRIPTION
This PR makes job runner class name move verbose. Now it's called `JobListener` and it doesn't expose it's responsibility. `JobRunner` will be much clearer.