### PR TITLE
Trim first slash in .env PAKET_BASE_URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `cybercog/laravel-paket` will be documented in this file.
 - ([#51]) Added refetch data button in top menu
 - ([#52]) Added polling to get realtime job output
 - ([#53]) Added requirement suggestions from Packagist.org
+- ([#55]) Trim first slash in .env PAKET_BASE_URI
 
 ## [1.4.0]
 

--- a/src/Http/Controllers/AppResponse.php
+++ b/src/Http/Controllers/AppResponse.php
@@ -35,7 +35,7 @@ final class AppResponse implements ResponsableContract
         return response()->view('paket::app', [
             'cssFile' => 'app.css',
             'paketScriptVariables' => [
-                'baseUri' => Config::get('paket.base_uri'),
+                'baseUri' => ltrim(Config::get('paket.base_uri'), '/'),
             ],
         ]);
     }

--- a/src/PaketServiceProvider.php
+++ b/src/PaketServiceProvider.php
@@ -47,7 +47,7 @@ final class PaketServiceProvider extends ServiceProvider
     {
         return [
             'namespace' => 'Cog\Laravel\Paket\Http\Controllers',
-            'prefix' => Config::get('paket.base_uri'),
+            'prefix' => ltrim(Config::get('paket.base_uri'), '/'),
             'middleware' => 'paket',
         ];
     }


### PR DESCRIPTION
This PR allows to set `BASE_URI` with prefix slash as well as without it.

Both of the variables will set panel URL: [http://127.0.0.1:8000/admin/paket](http://127.0.0.1:8000/admin/paket)
```dotenv
PAKET_BASE_URI=/admin/paket
PAKET_BASE_URI=admin/paket
```