### PR TITLE
Stop polling on unmount job item screen

### DIFF
--- a/resources/js/screens/jobs/item.vue
+++ b/resources/js/screens/jobs/item.vue
@@ -41,12 +41,17 @@
         data() {
             return {
                 job: {},
+                isMounted: true,
             };
         },
 
         mounted() {
             this.fetchData();
             this.autoRefreshData();
+        },
+
+        beforeDestroy() {
+            this.isMounted = false;
         },
 
         computed: {
@@ -62,6 +67,10 @@
         methods: {
             async autoRefreshData() {
                 setTimeout(async () => {
+                    if (this.isMounted === false) {
+                        return;
+                    }
+
                     if (this.job.status === 'Pending' || this.job.status === 'Running') {
                         await this.fetchData();
                         await this.autoRefreshData();


### PR DESCRIPTION
Fix permanent & duplicated polling to job resource API on unmounting\remounting job item screen component.